### PR TITLE
Update for Swift 6 with thread safety improvements

### DIFF
--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -2,15 +2,15 @@ name: macOS
 
 on:
   push:
-    branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
+    branches: ["**"]
 
 jobs:
   build:
     runs-on: macos-latest
-
     steps:
+    - uses: maxim-lobanov/setup-xcode@v1
+      with:
+        xcode-version: 16.0
     - uses: actions/checkout@v3
     - name: Build
       run: swift build -v

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -2,17 +2,18 @@ name: Ubuntu
 
 on:
   push:
-    branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
+    branches: ["**"]
 
 jobs:
   build:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Build
-      run: swift build -v
-    - name: Run tests
-      run: swift test -v
+      - uses: sersoft-gmbh/swifty-linux-action@v3
+        with:
+          release-version: 6.0.1
+      - uses: actions/checkout@v3
+      - name: Build for release
+        run: swift build -v -c release
+      - name: Test
+        run: swift test -v

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -2,19 +2,22 @@ name: Windows
 
 on:
   push:
-    branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
+    branches: ["**"]
 
 jobs:
   build:
     runs-on: windows-latest
     steps:
-      - uses: compnerd/gha-setup-swift@main
+      - uses: actions/checkout@v4
+
+      # ① Install Swift for Windows
+      - name: Set up Swift 6.1
+        uses: compnerd/gha-setup-swift@main
         with:
-          branch: swift-5.8-release
-          tag: 5.8-RELEASE
-  
-      - uses: actions/checkout@v2
+          branch: swift-6.1-release   # release branch
+          tag:    6.1-RELEASE         # exact toolchain tag
+
+      # ② Build & test
+      - run: swift --version          # sanity-check
       - run: swift build
       - run: swift test

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.6
+// swift-tools-version: 6.0
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 *A simple, lightweight caching library for Swift.*
 
+Requires **Swift 6.0** or later.
+
 ## What is Cache?
 
 Cache is a Swift library for caching arbitrary data types in memory. It provides a simple and intuitive API for storing, retrieving, and removing objects from the cache.

--- a/Sources/Cache/Cache/AnyCacheable.swift
+++ b/Sources/Cache/Cache/AnyCacheable.swift
@@ -4,7 +4,7 @@ public class AnyCacheable: Cacheable, @unchecked Sendable {
     public typealias Key = AnyHashable
     public typealias Value = Any
 
-    private let lock = NSLock()
+    private let lock = NSRecursiveLock()
     private var cache: any Cacheable
 
     private var cacheGet: ((AnyHashable) -> Any?)!

--- a/Sources/Cache/Cache/Cache.swift
+++ b/Sources/Cache/Cache/Cache.swift
@@ -13,7 +13,7 @@ import Foundation
  let age = cache.get("age") // age is now 100
  ```
  */
-open class Cache<Key: Hashable, Value>: Cacheable {
+open class Cache<Key: Hashable, Value>: Cacheable, @unchecked Sendable {
 
     /// Lock to synchronize the access to the cache dictionary.
     fileprivate var lock: NSLock

--- a/Sources/Cache/Cache/ComposableCache.swift
+++ b/Sources/Cache/Cache/ComposableCache.swift
@@ -1,5 +1,7 @@
 #if !os(Windows)
-public struct ComposableCache<Key: Hashable>: Cacheable {
+import Foundation
+public struct ComposableCache<Key: Hashable>: Cacheable, @unchecked Sendable {
+    private let lock = NSLock()
     private let caches: [AnyCacheable]
 
     public init(caches: [any Cacheable]) {
@@ -14,6 +16,7 @@ public struct ComposableCache<Key: Hashable>: Cacheable {
         _ key: Key,
         as: Output.Type = Output.self
     ) -> Output? {
+        lock.lock(); defer { lock.unlock() }
         for cache in caches {
             guard
                 let output = cache.get(key, as: Output.self)
@@ -31,6 +34,7 @@ public struct ComposableCache<Key: Hashable>: Cacheable {
         _ key: Key,
         as: Output.Type = Output.self
     ) throws -> Output {
+        lock.lock(); defer { lock.unlock() }
         for cache in caches {
             guard
                 let output = try? cache.resolve(key, as: Output.self)
@@ -45,18 +49,21 @@ public struct ComposableCache<Key: Hashable>: Cacheable {
     }
 
     public func set(value: Any, forKey key: Key) {
+        lock.lock(); defer { lock.unlock() }
         for cache in caches {
             cache.set(value: value, forKey: key)
         }
     }
 
     public func remove(_ key: Key) {
+        lock.lock(); defer { lock.unlock() }
         for cache in caches {
             cache.remove(key)
         }
     }
 
     public func contains(_ key: Key) -> Bool {
+        lock.lock(); defer { lock.unlock() }
         for cache in caches {
             if cache.contains(key) {
                 return true
@@ -67,6 +74,7 @@ public struct ComposableCache<Key: Hashable>: Cacheable {
     }
 
     public func require(keys: Set<Key>) throws -> ComposableCache<Key> {
+        lock.lock(); defer { lock.unlock() }
         for cache in caches {
             _ = try cache.require(keys: keys)
         }
@@ -75,6 +83,7 @@ public struct ComposableCache<Key: Hashable>: Cacheable {
     }
 
     public func require(_ key: Key) throws -> ComposableCache<Key> {
+        lock.lock(); defer { lock.unlock() }
         for cache in caches {
             _ = try cache.require(key)
         }
@@ -83,6 +92,7 @@ public struct ComposableCache<Key: Hashable>: Cacheable {
     }
 
     public func values<Output>(ofType: Output.Type) -> [Key: Output] {
+        lock.lock(); defer { lock.unlock() }
         for cache in caches {
             let values = cache.values(ofType: Output.self).compactMapKeys { $0 as? Key }
 

--- a/Sources/Cache/Cache/ComposableCache.swift
+++ b/Sources/Cache/Cache/ComposableCache.swift
@@ -1,7 +1,7 @@
 #if !os(Windows)
 import Foundation
 public struct ComposableCache<Key: Hashable>: Cacheable, @unchecked Sendable {
-    private let lock = NSLock()
+    private let lock = NSRecursiveLock()
     private let caches: [AnyCacheable]
 
     public init(caches: [any Cacheable]) {

--- a/Sources/Cache/Cache/ExpiringCache.swift
+++ b/Sources/Cache/Cache/ExpiringCache.swift
@@ -9,9 +9,9 @@ import Foundation
 
  Objects stored in the cache are automatically removed when their expiration duration has passed.
  */
-public class ExpiringCache<Key: Hashable, Value>: Cacheable {
+public class ExpiringCache<Key: Hashable, Value>: Cacheable, @unchecked Sendable {
     /// `Error` that reports expired values
-    public struct ExpiriedValueError: LocalizedError {
+    public struct ExpiriedValueError: LocalizedError, @unchecked Sendable {
         /// Expired key
         public let key: Key
 
@@ -71,7 +71,7 @@ public class ExpiringCache<Key: Hashable, Value>: Cacheable {
         }
     }
 
-    private struct ExpiringValue {
+    private struct ExpiringValue: @unchecked Sendable {
         let expriation: Date
         let value: Value
     }

--- a/Sources/Cache/Cache/LRUCache.swift
+++ b/Sources/Cache/Cache/LRUCache.swift
@@ -11,7 +11,8 @@ Error Handling: The set(value:forKey:) function does not throw any error. Instea
 
 The `LRUCache` class is a subclass of the `Cache` class. You can use its `capacity` property to specify the maximum number of key-value pairs that the cache can hold.
 */
-public class LRUCache<Key: Hashable, Value>: Cache<Key, Value> {
+public class LRUCache<Key: Hashable, Value>: Cache<Key, Value>, @unchecked Sendable {
+    private let lock = NSLock()
     private var keys: [Key]
 
     /// The maximum capacity of the cache.
@@ -46,6 +47,7 @@ public class LRUCache<Key: Hashable, Value>: Cache<Key, Value> {
     }
 
     public override func get<Output>(_ key: Key, as: Output.Type = Output.self) -> Output? {
+        lock.lock(); defer { lock.unlock() }
         guard let value = super.get(key, as: Output.self) else {
             return nil
         }
@@ -56,6 +58,7 @@ public class LRUCache<Key: Hashable, Value>: Cache<Key, Value> {
     }
 
     public override func set(value: Value, forKey key: Key) {
+        lock.lock(); defer { lock.unlock() }
         super.set(value: value, forKey: key)
 
         updateKeys(recentlyUsed: key)
@@ -63,6 +66,7 @@ public class LRUCache<Key: Hashable, Value>: Cache<Key, Value> {
     }
 
     public override func remove(_ key: Key) {
+        lock.lock(); defer { lock.unlock() }
         super.remove(key)
 
         if let index = keys.firstIndex(of: key) {
@@ -71,6 +75,7 @@ public class LRUCache<Key: Hashable, Value>: Cache<Key, Value> {
     }
 
     public override func contains(_ key: Key) -> Bool {
+        lock.lock(); defer { lock.unlock() }
         guard super.contains(key) else {
             return false
         }

--- a/Sources/Cache/Cache/LRUCache.swift
+++ b/Sources/Cache/Cache/LRUCache.swift
@@ -12,7 +12,7 @@ Error Handling: The set(value:forKey:) function does not throw any error. Instea
 The `LRUCache` class is a subclass of the `Cache` class. You can use its `capacity` property to specify the maximum number of key-value pairs that the cache can hold.
 */
 public class LRUCache<Key: Hashable, Value>: Cache<Key, Value>, @unchecked Sendable {
-    private let lock = NSLock()
+    private let lock = NSRecursiveLock()
     private var keys: [Key]
 
     /// The maximum capacity of the cache.

--- a/Sources/Cache/Cache/PersistableCache.swift
+++ b/Sources/Cache/Cache/PersistableCache.swift
@@ -42,7 +42,7 @@ import Foundation
  */
 public class PersistableCache<
     Key: RawRepresentable & Hashable, Value, PersistedValue
->: Cache<Key, Value> where Key.RawValue == String {
+>: Cache<Key, Value>, @unchecked Sendable where Key.RawValue == String {
     private let lock: NSLock = NSLock()
 
     /// The name of the cache. This will be used as the filename when saving to disk.

--- a/Sources/Cache/Errors/InvalidTypeError.swift
+++ b/Sources/Cache/Errors/InvalidTypeError.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// `Error` that reports the expected type for a value
-public struct InvalidTypeError<ExpectedType, ActualType>: LocalizedError {
+public struct InvalidTypeError<ExpectedType, ActualType>: LocalizedError, @unchecked Sendable {
     /// Expected type
     public let expectedType: ExpectedType.Type
 

--- a/Sources/Cache/Errors/MissingRequiredKeysError.swift
+++ b/Sources/Cache/Errors/MissingRequiredKeysError.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// `Error` that reports the required keys
-public struct MissingRequiredKeysError<Key: Hashable>: LocalizedError {
+public struct MissingRequiredKeysError<Key: Hashable>: LocalizedError, @unchecked Sendable {
     /// Required keys
     public let keys: Set<Key>
 

--- a/Sources/Cache/Global/Global+cache.swift
+++ b/Sources/Cache/Global/Global+cache.swift
@@ -1,4 +1,4 @@
 extension Global {
     /// The global cache for storing values.
-    public static var cache: Cache<AnyHashable, Any> = Cache()
+    public static let cache: Cache<AnyHashable, Any> = Cache()
 }

--- a/Sources/Cache/Global/Global+dependencies.swift
+++ b/Sources/Cache/Global/Global+dependencies.swift
@@ -1,4 +1,4 @@
 extension Global {
     /// The global cache for storing required dependencies.
-    public static var dependencies: RequiredKeysCache<AnyHashable, Any> = RequiredKeysCache()
+    public static let dependencies: RequiredKeysCache<AnyHashable, Any> = RequiredKeysCache()
 }

--- a/Sources/Cache/Global/Global+images.swift
+++ b/Sources/Cache/Global/Global+images.swift
@@ -11,6 +11,6 @@ extension Global {
     #endif
 
     /// The global cache for storing images.
-    public static var images: Cache<URL, CacheImage> = Cache()
+    public static let images: Cache<URL, CacheImage> = Cache()
 }
 #endif

--- a/Sources/Cache/Global/Global+loggers.swift
+++ b/Sources/Cache/Global/Global+loggers.swift
@@ -8,6 +8,6 @@ public typealias Logger = os.Logger
 @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)
 extension Global {
     /// The global cache for Loggers
-    public static var loggers: RequiredKeysCache<AnyHashable, Logger> = RequiredKeysCache()
+    public static let loggers: RequiredKeysCache<AnyHashable, Logger> = RequiredKeysCache()
 }
 #endif

--- a/Tests/CacheTests/ExampleTests.swift
+++ b/Tests/CacheTests/ExampleTests.swift
@@ -43,6 +43,7 @@ final class ExampleTests: XCTestCase {
         XCTAssertEqual(subclassObject.value, expectedValue)
     }
 
+    @MainActor
     func testObservedObjectExample() throws {
         struct ExampleView: View {
             enum Key {

--- a/Tests/CacheTests/ThreadSafetyTests.swift
+++ b/Tests/CacheTests/ThreadSafetyTests.swift
@@ -1,0 +1,41 @@
+import XCTest
+@testable import Cache
+
+final class ThreadSafetyTests: XCTestCase {
+    func testCacheConcurrentAccess() {
+        let iterations = 1000
+        let cache = Cache<Int, Int>()
+
+        DispatchQueue.concurrentPerform(iterations: iterations) { i in
+            cache.set(value: i, forKey: i)
+            XCTAssertEqual(cache.get(i), i)
+            cache.remove(i)
+        }
+
+        XCTAssertEqual(cache.allValues.count, 0)
+    }
+
+    func testLRUCacheConcurrentAccess() {
+        let iterations = 500
+        let cache = LRUCache<Int, Int>(capacity: 500)
+
+        DispatchQueue.concurrentPerform(iterations: iterations) { i in
+            cache.set(value: i, forKey: i)
+            XCTAssertEqual(cache.get(i), i)
+        }
+
+        XCTAssertEqual(cache.allValues.count, 500)
+    }
+
+    func testExpiringCacheConcurrentAccess() {
+        let iterations = 200
+        let cache = ExpiringCache<Int, Int>(duration: .hours(1))
+
+        DispatchQueue.concurrentPerform(iterations: iterations) { i in
+            cache.set(value: i, forKey: i)
+            XCTAssertEqual(cache.get(i), i)
+        }
+
+        XCTAssertEqual(cache.allValues.count, iterations)
+    }
+}


### PR DESCRIPTION
## Summary
- update to Swift 6 toolchain
- note Swift 6 requirement in README
- secure caches using locks and mark types `@unchecked Sendable`
- make global caches immutable

## Testing
- `swift build --scratch-path .scratch` *(fails: Another instance of SwiftPM is already running)*

------
https://chatgpt.com/codex/tasks/task_e_683f8e08cbf08326a86d42119c836f4d