### PR TITLE
Add concurrency stress tests

### DIFF
--- a/Tests/CacheTests/ThreadSafetyTests.swift
+++ b/Tests/CacheTests/ThreadSafetyTests.swift
@@ -24,12 +24,12 @@ final class ThreadSafetyTests: XCTestCase {
             XCTAssertEqual(cache.get(i), i)
         }
 
-        XCTAssertEqual(cache.allValues.count, iterations)
+        XCTAssertEqual(cache.allValues.count, 5)
     }
 
     func testExpiringCacheConcurrentAccess() {
         let iterations = 200
-        let cache = ExpiringCache<Int, Int>(duration: .seconds(1))
+        let cache = ExpiringCache<Int, Int>(duration: .hours(1))
 
         DispatchQueue.concurrentPerform(iterations: iterations) { i in
             cache.set(value: i, forKey: i)

--- a/Tests/CacheTests/ThreadSafetyTests.swift
+++ b/Tests/CacheTests/ThreadSafetyTests.swift
@@ -17,14 +17,14 @@ final class ThreadSafetyTests: XCTestCase {
 
     func testLRUCacheConcurrentAccess() {
         let iterations = 500
-        let cache = LRUCache<Int, Int>(capacity: 5)
+        let cache = LRUCache<Int, Int>(capacity: 500)
 
         DispatchQueue.concurrentPerform(iterations: iterations) { i in
             cache.set(value: i, forKey: i)
             XCTAssertEqual(cache.get(i), i)
         }
 
-        XCTAssertEqual(cache.allValues.count, 5)
+        XCTAssertEqual(cache.allValues.count, 500)
     }
 
     func testExpiringCacheConcurrentAccess() {

--- a/Tests/CacheTests/ThreadSafetyTests.swift
+++ b/Tests/CacheTests/ThreadSafetyTests.swift
@@ -17,7 +17,7 @@ final class ThreadSafetyTests: XCTestCase {
 
     func testLRUCacheConcurrentAccess() {
         let iterations = 500
-        let cache = LRUCache<Int, Int>(capacity: UInt(iterations))
+        let cache = LRUCache<Int, Int>(capacity: 5)
 
         DispatchQueue.concurrentPerform(iterations: iterations) { i in
             cache.set(value: i, forKey: i)
@@ -29,7 +29,7 @@ final class ThreadSafetyTests: XCTestCase {
 
     func testExpiringCacheConcurrentAccess() {
         let iterations = 200
-        let cache = ExpiringCache<Int, Int>(duration: .hours(1))
+        let cache = ExpiringCache<Int, Int>(duration: .seconds(1))
 
         DispatchQueue.concurrentPerform(iterations: iterations) { i in
             cache.set(value: i, forKey: i)

--- a/Tests/CacheTests/ThreadSafetyTests.swift
+++ b/Tests/CacheTests/ThreadSafetyTests.swift
@@ -1,0 +1,41 @@
+import XCTest
+@testable import Cache
+
+final class ThreadSafetyTests: XCTestCase {
+    func testCacheConcurrentAccess() {
+        let iterations = 1000
+        let cache = Cache<Int, Int>()
+
+        DispatchQueue.concurrentPerform(iterations: iterations) { i in
+            cache.set(value: i, forKey: i)
+            XCTAssertEqual(cache.get(i), i)
+            cache.remove(i)
+        }
+
+        XCTAssertEqual(cache.allValues.count, 0)
+    }
+
+    func testLRUCacheConcurrentAccess() {
+        let iterations = 500
+        let cache = LRUCache<Int, Int>(capacity: UInt(iterations))
+
+        DispatchQueue.concurrentPerform(iterations: iterations) { i in
+            cache.set(value: i, forKey: i)
+            XCTAssertEqual(cache.get(i), i)
+        }
+
+        XCTAssertEqual(cache.allValues.count, iterations)
+    }
+
+    func testExpiringCacheConcurrentAccess() {
+        let iterations = 200
+        let cache = ExpiringCache<Int, Int>(duration: .hours(1))
+
+        DispatchQueue.concurrentPerform(iterations: iterations) { i in
+            cache.set(value: i, forKey: i)
+            XCTAssertEqual(cache.get(i), i)
+        }
+
+        XCTAssertEqual(cache.allValues.count, iterations)
+    }
+}


### PR DESCRIPTION
## Summary
- add new `ThreadSafetyTests` covering concurrent access for Cache, LRUCache and ExpiringCache

## Testing
- `swift test --enable-test-discovery`

------
https://chatgpt.com/codex/tasks/task_e_683fada8576c832683298db893b1841f