### PR TITLE
ci: upgrade actions/checkout to v4 and add PR triggers

### DIFF
--- a/.github/workflows/docc.yml
+++ b/.github/workflows/docc.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Xcode
         uses: maxim-lobanov/setup-xcode@v1
@@ -48,7 +48,7 @@ jobs:
         uses: actions/configure-pages@v5
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           path: docs
 

--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -3,6 +3,8 @@ name: macOS
 on:
   push:
     branches: ["**"]
+  pull_request:
+    branches: ["main"]
 
 jobs:
   build:
@@ -11,7 +13,7 @@ jobs:
     - uses: maxim-lobanov/setup-xcode@v1
       with:
         xcode-version: 16.0
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Build
       run: swift build -v
     - name: Run tests

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -3,6 +3,8 @@ name: Ubuntu
 on:
   push:
     branches: ["**"]
+  pull_request:
+    branches: ["main"]
 
 jobs:
   build:
@@ -13,7 +15,7 @@ jobs:
         uses: swift-actions/setup-swift@v2
         with: 
           swift-version: '6.1.0'
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Build for release
         run: swift build -v -c release
       - name: Test

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -3,6 +3,8 @@ name: Windows
 on:
   push:
     branches: ["**"]
+  pull_request:
+    branches: ["main"]
 
 jobs:
   build:


### PR DESCRIPTION
## Summary

- Upgrade `actions/checkout` from v3 to v4 in docc, macOS, and ubuntu workflows
- Upgrade `actions/upload-pages-artifact` from v3 to v4 in docc workflow
- Add `pull_request` triggers targeting `main` to macOS, ubuntu, and windows workflows
- docc workflow kept as push-to-main only (it deploys GitHub Pages)

Closes #28

## Test plan

- [ ] Verify macOS, ubuntu, and windows workflows run on this PR
- [ ] Verify docc workflow is not triggered by this PR (push-to-main only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)