### PR TITLE
Support WebAssembly + fix Linux collection-cast crash

### DIFF
--- a/Sources/Cache/Cache/Cache.swift
+++ b/Sources/Cache/Cache/Cache.swift
@@ -19,11 +19,14 @@ open class Cache<Key: Hashable, Value>: Cacheable, @unchecked Sendable {
     /// Using NSRecursiveLock to prevent re-entrant lock deadlocks with @Published property wrapper
     fileprivate var lock: NSRecursiveLock
 
-    #if os(Linux) || os(Windows)
-    fileprivate var cache: [Key: Value] = [:]
-    #else
+    #if canImport(Combine)
     /// The actual cache dictionary of key-value pairs.
     @Published fileprivate var cache: [Key: Value] = [:]
+    #else
+    // Combine (and therefore `@Published`) is unavailable on Linux, Windows, and
+    // WebAssembly (`os(WASI)`). Guarding on `canImport(Combine)` — rather than
+    // `!os(Linux) && !os(Windows)` — correctly excludes wasm too.
+    fileprivate var cache: [Key: Value] = [:]
     #endif
 
     /**
@@ -160,7 +163,7 @@ open class Cache<Key: Hashable, Value>: Cacheable, @unchecked Sendable {
     }
 }
 
-#if !os(Linux) && !os(Windows)
+#if canImport(Combine)
 extension Cache: ObservableObject { }
 #endif
 

--- a/Sources/Cache/Dictionary/Dictionary+Cacheable.swift
+++ b/Sources/Cache/Dictionary/Dictionary+Cacheable.swift
@@ -15,7 +15,13 @@ extension Dictionary: Cacheable {
     - Returns: The casted value for the given key, or `nil` if the key doesn't exist or the cast fails.
     */
     public func get<Item>(_ key: Key, as: Item.Type = Item.self) -> Item? {
-        guard let value = self[key] as? Item else {
+        // Route through an explicit `Any` boxing step before the conditional cast. This avoids
+        // `swift_dynamicCastFailure` / `_arrayForceCast` aborts on Linux and WASI when casting an
+        // `Optional<Any>` that wraps a collection type (e.g. `[SomeStruct]`): without the
+        // intermediate cast, the runtime takes the `Optional<Any>` → `[T]` forced-array-cast path,
+        // which is not implemented the same way off Darwin. Boxing to `Any` first normalises the
+        // dynamic type to the concrete `Item` path.
+        guard let value = (self[key] as Any) as? Item else {
             return nil
         }
 

--- a/Tests/CacheTests/CacheTests.swift
+++ b/Tests/CacheTests/CacheTests.swift
@@ -287,4 +287,36 @@ final class CacheTests: XCTestCase {
 
         XCTAssertEqual(cache[.text, default: "missing value"], "missing value")
     }
+
+    // MARK: - Issue #151 — collection-typed values through an `Any` cache
+
+    private struct Point: Equatable {
+        let x: Int
+        let y: Int
+    }
+
+    func testArrayOfStructsRoundTripThroughAnyCache() {
+        let cache: Cache<String, Any> = Cache()
+        let points = [Point(x: 1, y: 2), Point(x: 3, y: 4)]
+        cache.set(value: points, forKey: "points")
+
+        let resolved: [Point]? = cache.get("points", as: [Point].self)
+        XCTAssertEqual(resolved, points)
+    }
+
+    func testArrayOfStringsRoundTripThroughAnyCache() {
+        let cache: Cache<String, Any> = Cache()
+        cache.set(value: ["a", "b", "c"], forKey: "letters")
+
+        XCTAssertEqual(cache.get("letters", as: [String].self), ["a", "b", "c"])
+    }
+
+    func testArrayResolveRoundTripThroughAnyCache() throws {
+        let cache: Cache<String, Any> = Cache()
+        let values = [10, 20, 30]
+        cache.set(value: values, forKey: "values")
+
+        let resolved: [Int] = try cache.resolve("values", as: [Int].self)
+        XCTAssertEqual(resolved, values)
+    }
 }


### PR DESCRIPTION
Two cross-platform fixes (baselined on 2.1.x, the line AppState 3.0 depends on).

## WebAssembly build (AppState#149)
`@Published`/`ObservableObject` were gated with `#if os(Linux) || os(Windows)` / `#if !os(Linux) && !os(Windows)`. WebAssembly is `os(WASI)` — neither Linux nor Windows — so wasm took the Combine path and failed to build (`unknown attribute 'Published'`, `cannot find type 'ObservableObject'`). Switched both to `#if canImport(Combine)`, which correctly excludes Linux, Windows, **and** wasm.

## Linux collection-cast crash (AppState#151)
`Dictionary.get(_:as:)` did `self[key] as? Item`. When the store is `Cache<String, Any>` and `Item` is a collection (e.g. `[SomeStruct]`), casting `Optional<Any> → [T]` takes the runtime `_arrayForceCast` path, which aborts (`swift_dynamicCastFailure`) on Linux/WASI. Boxing through `Any` first — `(self[key] as Any) as? Item` — normalises the cast and avoids the abort.

## Tests
Added array round-trip regression tests through `Cache<String, Any>`. **178 tests pass on macOS.**

Closes the Cache side of AppState#149 and AppState#151.