### PR TITLE
Fix CI and prep 2.1.3 for AppState 3.0

### DIFF
--- a/.github/workflows/docc.yml
+++ b/.github/workflows/docc.yml
@@ -18,7 +18,7 @@ jobs:
     environment:
       name: github-pages
       url: '${{ steps.deployment.outputs.page_url }}'
-    runs-on: macos-latest
+    runs-on: macos-15
 
     steps:
       - name: Checkout code
@@ -27,12 +27,7 @@ jobs:
       - name: Setup Xcode
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: 16.0
-
-      - name: Set up Swift
-        uses: swift-actions/setup-swift@v2
-        with:
-          swift-version: '6.1.0'
+          xcode-version: latest-stable
 
       - name: Build and Export DocC
         run: |

--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -8,11 +8,11 @@ on:
 
 jobs:
   build:
-    runs-on: macos-latest
+    runs-on: macos-15
     steps:
     - uses: maxim-lobanov/setup-xcode@v1
       with:
-        xcode-version: 16.0
+        xcode-version: latest-stable
     - uses: actions/checkout@v4
     - name: Build
       run: swift build -v

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,32 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [2.1.3] - 2026-07-17
+
+Release intended for consumers such as **AppState 3.0**, which can replace a revision pin of Cache#30 with `from: "2.1.3"`.
+
+### Fixed
+
+- **WebAssembly / WASI builds** — Guard `@Published` / `ObservableObject` with `#if canImport(Combine)` instead of `#if !os(Linux) && !os(Windows)`, so wasm no longer takes the Combine path ([#30](https://github.com/0xLeif/Cache/pull/30), AppState#149).
+- **Linux / WASI collection cast crash** — `Dictionary.get(_:as:)` unwraps the optional value before casting, avoiding `swift_dynamicCastFailure` / `_arrayForceCast` aborts when reading collection-typed values from an `Any` cache ([#30](https://github.com/0xLeif/Cache/pull/30), AppState#151).
+- **CI** — macOS and DocC workflows no longer pin Xcode 16 (unavailable on current `macos-latest` images). Use `macos-15` with `latest-stable` Xcode, matching AppState.
+
+### Changed
+
+- Explicitly import Combine when available so `@Published` / `ObservableObject` compile reliably across build configurations.
+
+## [2.1.2] - 2025-09-20
+
+### Added
+
+- DocC plugin dependency and GitHub Pages documentation workflow updates.
+
+[Unreleased]: https://github.com/0xLeif/Cache/compare/2.1.3...HEAD
+[2.1.3]: https://github.com/0xLeif/Cache/compare/2.1.2...2.1.3
+[2.1.2]: https://github.com/0xLeif/Cache/releases/tag/2.1.2

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Cache is a Swift library for caching arbitrary data types in memory. It provides
 - Flexible caching, allowing for multiple Cache objects with different configurations
 - Thread-safe implementation
 - Property Wrappers
+- Cross-platform: Apple platforms, Linux, Windows, and WebAssembly (WASI)
 
 ## Installation
 
@@ -24,7 +25,7 @@ Add the following line to your `Package.swift` file in the dependencies array:
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/0xLeif/Cache.git", from: "2.0.0")
+    .package(url: "https://github.com/0xLeif/Cache.git", from: "2.1.3")
 ]
 ```
 

--- a/Sources/Cache/Cache/Cache.swift
+++ b/Sources/Cache/Cache/Cache.swift
@@ -1,5 +1,9 @@
 import Foundation
 
+#if canImport(Combine)
+import Combine
+#endif
+
 /**
  `Cache` class provides a cache functionality that can be used to store key-value pairs. It is thread-safe using a locking mechanism.
 

--- a/Sources/Cache/Dictionary/Dictionary+Cacheable.swift
+++ b/Sources/Cache/Dictionary/Dictionary+Cacheable.swift
@@ -15,13 +15,11 @@ extension Dictionary: Cacheable {
     - Returns: The casted value for the given key, or `nil` if the key doesn't exist or the cast fails.
     */
     public func get<Item>(_ key: Key, as: Item.Type = Item.self) -> Item? {
-        // Route through an explicit `Any` boxing step before the conditional cast. This avoids
-        // `swift_dynamicCastFailure` / `_arrayForceCast` aborts on Linux and WASI when casting an
-        // `Optional<Any>` that wraps a collection type (e.g. `[SomeStruct]`): without the
-        // intermediate cast, the runtime takes the `Optional<Any>` → `[T]` forced-array-cast path,
-        // which is not implemented the same way off Darwin. Boxing to `Any` first normalises the
-        // dynamic type to the concrete `Item` path.
-        guard let value = (self[key] as Any) as? Item else {
+        // Unwrap the optional value first. Casting `Optional<Any>` (or `Optional<Value>`)
+        // directly to a collection type (e.g. `[T]`) can abort on Linux/WASI with
+        // `swift_dynamicCastFailure` / `_arrayForceCast`. Unwrapping first takes the
+        // concrete `Value` → `Item` path instead.
+        guard let rawValue = self[key], let value = rawValue as? Item else {
             return nil
         }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes broken **CI** and prepares Cache for a **2.1.3** tag so AppState 3.0 can drop its revision pin of [#30](https://github.com/0xLeif/Cache/pull/30).

### CI
macOS and DocC were failing on `main` with:

> Could not find Xcode version that satisfied version spec: '16'

Current `macos-latest` images only ship Xcode 26.x. Aligned with AppState:

- `runs-on: macos-15`
- `xcode-version: latest-stable`
- Dropped the redundant `swift-actions/setup-swift` step from DocC (Xcode toolchain is enough)

### Release polish (post-#30 review)
- `Dictionary.get(_:as:)` unwraps the optional before casting (idiomatic fix for the Linux/WASI `_arrayForceCast` abort)
- Explicit `import Combine` when available for `@Published` / `ObservableObject`
- `CHANGELOG.md` + README pin guidance for **2.1.3**

### After merge
Please tag **`2.1.3`** from `main`. AppState can then switch from:

```swift
.package(url: "https://github.com/0xLeif/Cache", revision: "33ef0d7…")
```

to:

```swift
.package(url: "https://github.com/0xLeif/Cache.git", from: "2.1.3")
```

## Test plan
- [x] macOS workflow green on this PR
- [x] Ubuntu / Windows workflows still green
- [ ] DocC will re-verify on merge to `main`
- [ ] Maintainer tags `2.1.3` after merge

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f71c1-8e58-7bb3-a3a6-dd457e6cc2ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f71c1-8e58-7bb3-a3a6-dd457e6cc2ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

